### PR TITLE
Fix file path checks

### DIFF
--- a/OpenPgp.FluentApi.UnitTest/FluentAPIUnitTest.cs
+++ b/OpenPgp.FluentApi.UnitTest/FluentAPIUnitTest.cs
@@ -76,6 +76,50 @@ namespace OpenPgp.FluentApi.UnitTest
             Assert.Equal(PlainMessage, decryptedText);
         }
 
+
+        [Fact]
+        public void TestEncrypt_Decrypt_AESAlgorithm()
+        {
+            PlainMessageStream.Seek(0, SeekOrigin.Begin);
+            PublicKey1.Seek(0, SeekOrigin.Begin);
+            PrivateKey1.Seek(0, SeekOrigin.Begin);
+            PublicKey2.Seek(0, SeekOrigin.Begin);
+            PrivateKey2.Seek(0, SeekOrigin.Begin);
+
+            var encryptionTask = new PgpEncryptionBuilder()
+                .Encrypt(PlainMessageStream)
+                .WithArmor()
+                .WithCompression()
+                .WithIntegrityCheck()
+                .WithSymmetricKeyAlgorithm(Org.BouncyCastle.Bcpg.SymmetricKeyAlgorithmTag.Aes256)
+                .WithPublicKey(PublicKey1)
+                .Build();
+
+            var encryptedStream = encryptionTask.Run().GetEncryptedStream();
+
+            var encryptedText = new StreamReader(encryptedStream).ReadToEnd();
+
+
+            encryptedStream.Seek(0, SeekOrigin.Begin);
+            PlainMessageStream.Seek(0, SeekOrigin.Begin);
+            PublicKey1.Seek(0, SeekOrigin.Begin);
+            PrivateKey1.Seek(0, SeekOrigin.Begin);
+            PublicKey2.Seek(0, SeekOrigin.Begin);
+            PrivateKey2.Seek(0, SeekOrigin.Begin);
+
+
+            var decryptionTask = new PgpDecryptionBuilder()
+                .Decrypt(encryptedStream)
+                .WithPrivateKey(PrivateKey1, PassPhrase1)
+                .Build();
+
+            var decryptedStream = decryptionTask.Run().GetDecryptedStream();
+
+            var decryptedText = new StreamReader(decryptedStream).ReadToEnd();
+
+            Assert.Equal(PlainMessage, decryptedText);
+        }
+
         [Fact]
         public void TestEncrypt_Decrypt_2KeysAndNoSignatures()
         {

--- a/OpenPgp.FluentApi.UnitTest/OpenPgp.FluentApi.UnitTest.csproj
+++ b/OpenPgp.FluentApi.UnitTest/OpenPgp.FluentApi.UnitTest.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OpenPgp.FluentApi.UnitTest/OpenPgp.FluentApi.UnitTest.csproj
+++ b/OpenPgp.FluentApi.UnitTest/OpenPgp.FluentApi.UnitTest.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi.csproj
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.2" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
   </ItemGroup>
 
 </Project>

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi.csproj
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi.csproj
@@ -9,9 +9,9 @@
     <Description>Friendly API for bouncy castle open pgp library</Description>
     <PackageLicenseUrl>https://github.com/mohamedfarouk/openpgp-fluentapi/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/mohamedfarouk/openpgp-fluentapi</PackageProjectUrl>
-    <Version>1.1.2</Version>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpDecryptionBuilder.cs
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpDecryptionBuilder.cs
@@ -98,8 +98,8 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
             if (string.IsNullOrEmpty(privateKeyPath))
                 throw new ArgumentNullException("privateKeyPath");
 
-            if (!Uri.IsWellFormedUriString(privateKeyPath, UriKind.RelativeOrAbsolute))
-                throw new ArgumentException("privateKeyPath", "malformed file path");
+            if (!Utils.IsPathValid(privateKeyPath, out string pathError))
+                throw new ArgumentException("privateKeyPath", pathError);
 
             if (!File.Exists(privateKeyPath))
                 throw new ArgumentException("privateKeyPath", "file does not exists");
@@ -136,8 +136,8 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
             if (string.IsNullOrEmpty(signatureKeyPath))
                 throw new ArgumentNullException("signatureKeyPath");
 
-            if (!Uri.IsWellFormedUriString(signatureKeyPath, UriKind.RelativeOrAbsolute))
-                throw new ArgumentException("signatureKeyPath", "malformed file path");
+            if (!Utils.IsPathValid(signatureKeyPath, out string pathError))
+                throw new ArgumentException("signatureKeyPath", pathError);
 
             if (!File.Exists(signatureKeyPath))
                 throw new ArgumentException("signatureKeyPath", "file does not exists");

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionBuilder.cs
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionBuilder.cs
@@ -24,6 +24,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
         private bool Armor;
         private bool Compress;
         private bool IntegrityCheck;
+        private SymmetricKeyAlgorithmTag SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Cast5;
         private bool SignOutput;
 
         #region Fluent API
@@ -162,6 +163,12 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
             return this;
         }
 
+        public PgpEncryptionBuilder WithSymmetricKeyAlgorithm(SymmetricKeyAlgorithmTag symmetricKeyAlgorithm)
+        {
+            this.SymmetricKeyAlgorithm = symmetricKeyAlgorithm;
+            return this;
+        }
+
         public PgpEncryptionBuilder WithSigning(string signKeyFilePath, string password)
         {
             if (string.IsNullOrEmpty(signKeyFilePath))
@@ -225,6 +232,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
                 Armor = Armor,
                 Compress = Compress,
                 WithIntegrityCheck = IntegrityCheck,
+                SymmetricKeyAlgorithm = SymmetricKeyAlgorithm,
                 WithSigning = SignOutput
             };
         }

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionBuilder.cs
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionBuilder.cs
@@ -85,8 +85,8 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
             if (string.IsNullOrEmpty(outfilePath))
                 throw new ArgumentNullException("outfilePath");
 
-            if (!Uri.IsWellFormedUriString(outfilePath, UriKind.RelativeOrAbsolute))
-                throw new ArgumentException("outfilePath", "malformed file path");
+            if (!Utils.IsPathValid(outfilePath, out string pathError))
+                throw new ArgumentException("outfilePath", pathError);
 
             try
             {
@@ -118,8 +118,8 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
             if (string.IsNullOrEmpty(publicKeyPath))
                 throw new ArgumentNullException("inputFilePath");
 
-            if (!Uri.IsWellFormedUriString(publicKeyPath, UriKind.RelativeOrAbsolute))
-                throw new ArgumentException("inputFilePath", "malformed file path");
+            if (!Utils.IsPathValid(publicKeyPath, out string pathError))
+                throw new ArgumentException("inputFilePath", pathError);
 
             if (!File.Exists(publicKeyPath))
                 throw new ArgumentException("inputFilePath", "file does not exists");
@@ -173,9 +173,9 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
         {
             if (string.IsNullOrEmpty(signKeyFilePath))
                 throw new ArgumentNullException("signKeyFilePath");
-
-            if (!Uri.IsWellFormedUriString(signKeyFilePath, UriKind.RelativeOrAbsolute))
-                throw new ArgumentException("signKeyFilePath", "malformed file path");
+            
+            if (!Utils.IsPathValid(signKeyFilePath, out string pathError))
+                throw new ArgumentException("signKeyFilePath", pathError);
 
             if (!File.Exists(signKeyFilePath))
                 throw new ArgumentException("signKeyFilePath", "file does not exists");

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionTask.cs
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/PgpEncryptionTask.cs
@@ -15,7 +15,8 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
 
         internal bool Armor;
         internal bool Compress;
-        internal bool WithIntegrityCheck;
+        internal bool WithIntegrityCheck;        
+        internal SymmetricKeyAlgorithmTag SymmetricKeyAlgorithm;
         internal bool WithSigning;
 
 
@@ -48,7 +49,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
                 var InStream = InFile.OpenRead();
                 var OutStream = OutFile.OpenWrite();
 
-                PgpEncryptedDataGenerator encGen = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithmTag.Cast5, WithIntegrityCheck, new SecureRandom());
+                PgpEncryptedDataGenerator encGen = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, WithIntegrityCheck, new SecureRandom());
 
                 foreach (var publicKey in PublicKeys)
                 {

--- a/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Utils.cs
+++ b/Org.BouncyCastle.Bcpg.OpenPgp.FluentApi/Utils.cs
@@ -80,5 +80,20 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp.FluentApi
 
             return tempFile;
         }
+
+        internal static bool IsPathValid(string path, out string error)
+        {
+            error = null;
+            try
+            {
+                var fullPath = Path.GetFullPath(path);
+            }
+            catch(Exception ex)
+            {
+                error = $"{ex.GetType().Name}, {ex.Message}";
+                return false;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Ensure any file path are validated correctly as a local file in the below formats


```
"/work/anything/something.txt" //linux like path
"work/anything/something.txt" //relative path
"./work/anything/something.txt" //relative path
"//network/work/anything/something.txt" //windows network path
"C:/work/anything/something.txt" //windows absolute path
```